### PR TITLE
support for package options

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ kickstart { '/var/www/html/kickstart.cfg':
 }
 ```
 
-You can pass a list of packages to install using the `packages` parameter:
+You can pass a list of packages to install using the `packages` parameter, with an `Array` of packages:
 
 ```
 kickstart { '/var/www/html/kickstart.cfg':
@@ -120,7 +120,7 @@ kickstart { '/var/www/html/kickstart.cfg':
 }
 ```
 
-or the hash version:
+or `packages` parameter with a `Hash` of options and packages:
 
 ```
 kickstart { '/var/www/html/kickstart.cfg':

--- a/README.md
+++ b/README.md
@@ -120,6 +120,22 @@ kickstart { '/var/www/html/kickstart.cfg':
 }
 ```
 
+or the hash version:
+
+```
+kickstart { '/var/www/html/kickstart.cfg':
+  packages => {
+    'package_list' => [
+      '@base',
+      'redhat-lsb',
+      'apache',
+      'mariadb-server',
+      'nagios-nrpe'
+    ]
+  }
+}
+```
+
 This would result in the following snippet:
 
 ```
@@ -129,6 +145,30 @@ This would result in the following snippet:
 redhat-lsb
 apache
 mariadb-server
+nagios-nrpe
+%end
+```
+
+You can pass a list of packages, with options, to install using the `packages` parameter:
+
+```
+kickstart { '/var/www/html/kickstart.cfg':
+  packages => {
+    'options' => '--nobase --ignoremissing',
+    'package_list' => [
+      '@core',
+      'nagios-nrpe'
+    ]
+  }
+}
+```
+
+This would result in the following snippet:
+
+```
+# Packages Section
+%packages --nobase --ignoremissing
+@core
 nagios-nrpe
 %end
 ```

--- a/README.md
+++ b/README.md
@@ -120,22 +120,6 @@ kickstart { '/var/www/html/kickstart.cfg':
 }
 ```
 
-or `packages` parameter with a `Hash` of options and packages:
-
-```
-kickstart { '/var/www/html/kickstart.cfg':
-  packages => {
-    'package_list' => [
-      '@base',
-      'redhat-lsb',
-      'apache',
-      'mariadb-server',
-      'nagios-nrpe'
-    ]
-  }
-}
-```
-
 This would result in the following snippet:
 
 ```
@@ -154,7 +138,7 @@ You can pass a list of packages, with options, to install using the `packages` p
 ```
 kickstart { '/var/www/html/kickstart.cfg':
   packages => {
-    'options' => '--nobase --ignoremissing',
+    'options'      => '--nobase --ignoremissing',
     'package_list' => [
       '@core',
       'nagios-nrpe'

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -41,6 +41,31 @@
 #
 # [*packages*]
 #   Array. An array of package names.
+#   Hash. A hash containing package options, and also the package list
+#
+#   Example: As Array
+#
+#   kickstart { '/var/www/html/kickstart.cfg':
+#     packages => [
+#       '@base',
+#       'redhat-lsb',
+#       'apache',
+#       'mariadb-server',
+#       'nagios-nrpe'
+#     ]
+#   }
+#
+#   Example: As Hash
+#
+#   kickstart { '/var/www/html/kickstart.cfg':
+#     packages => {
+#       'options' => '--nobase',
+#       'package_list' => [
+#         '@core',
+#       ]
+#     }
+#   }
+#                                                 }
 # [*partition_configuration*]
 #   Hash. A separate section to define your partition configuration. This
 #   follows the same rules as the 'commands' parameter.
@@ -100,7 +125,13 @@ define kickstart (
   validate_hash($commands)
 
   if $repos { validate_hash($repos) }
-  if $packages { validate_array($packages) }
+  if $packages {
+    if is_array($packages) {
+      validate_array($packages)
+    } else {
+      validate_hash($packages)
+    }
+  }
   if $partition_configuration { validate_hash($partition_configuration) }
   if $fragments { validate_hash($fragments) }
   if $fragment_variables { validate_hash($fragment_variables) }

--- a/spec/defines/kickstart_spec.rb
+++ b/spec/defines/kickstart_spec.rb
@@ -160,12 +160,7 @@ describe 'kickstart' do
     end
 
     it { is_expected.to compile }
-    it { is_expected.to contain_file(title).with_content /^%pre$\s(^.*$)\s^%end$/m }
-    it { is_expected.to contain_file(title).with_content /^THIS IS A pre SCRIPT!$/ }
-    it { is_expected.to contain_file(title).with_content /^%post --nochroot$\s(^.*$)\s^%end$/m }
-    it { is_expected.to contain_file(title).with_content /^THIS IS A post SCRIPT WITH nochroot!$/ }
-    it { is_expected.to contain_file(title).with_content /^%post$\s(^.*$)\s^%end$/m }
-    it { is_expected.to contain_file(title).with_content /^THIS IS A post SCRIPT!$/ }
+    it { is_expected.to contain_file(title).with_content /^%pre$\s(^.*$)\s^%end$\s^%post --nochroot$\s(^.*$)\s^%end$\s^%post$\s(^.*$)\s^%end$/m }
   end
 
 end

--- a/spec/defines/kickstart_spec.rb
+++ b/spec/defines/kickstart_spec.rb
@@ -104,6 +104,26 @@ describe 'kickstart' do
     end
   end
 
+  context 'when handling packages hash with options' do
+    let(:packages) { {'options' => '--nobase --ignoremissing', 'package_list' => [ '@core', 'authconfig', 'system-config-firewall-base']} }
+
+    it { is_expected.to compile }
+    it { is_expected.to contain_file(title).with_content /^%packages --nobase --ignoremissing$\s+(^[\S\s]+$)\s+^%end$/ }
+  end
+
+  context 'when handling packages hash without options' do
+    let(:packages) { {'package_list' => [ '@core', 'authconfig', 'system-config-firewall-base']} }
+
+    it { is_expected.to compile }
+    it { is_expected.to contain_file(title).with_content /^%packages$\s+(^[\S\s]+$)\s+^%end$/ }
+  end
+
+  context 'when packages is not an array or hash' do
+    let(:packages) { 'package_list' }
+
+    it { is_expected.not_to compile }
+  end
+
   context 'handling false values' do
     let(:falsey_commands) {{ 'foo' => false, 'bar' => 'false' }}
     let(:params) {{ :commands => falsey_commands, :fail_on_unsupported_commands => false }}

--- a/spec/defines/kickstart_spec.rb
+++ b/spec/defines/kickstart_spec.rb
@@ -148,4 +148,24 @@ describe 'kickstart' do
     it { is_expected.not_to compile }
     it { is_expected.to raise_error Puppet::Error, /Unsupported Kickstart commands/ }
   end
+
+  context 'when multiple fragments for pre/post are provided' do
+    let(:fragment_variables) {{ 'kind' => 'post', 'other_kind' => 'pre', 'opts' => 'nochroot' }}
+    let(:fragments) do
+      {
+        'pre' => ["#{fixture_path}/templates/pre.erb"],
+        'post --nochroot' => ["#{fixture_path}/templates/post_opts.erb"],
+        'post' => ["#{fixture_path}/templates/post.erb"]
+      }
+    end
+
+    it { is_expected.to compile }
+    it { is_expected.to contain_file(title).with_content /^%pre$\s(^.*$)\s^%end$/m }
+    it { is_expected.to contain_file(title).with_content /^THIS IS A pre SCRIPT!$/ }
+    it { is_expected.to contain_file(title).with_content /^%post --nochroot$\s(^.*$)\s^%end$/m }
+    it { is_expected.to contain_file(title).with_content /^THIS IS A post SCRIPT WITH nochroot!$/ }
+    it { is_expected.to contain_file(title).with_content /^%post$\s(^.*$)\s^%end$/m }
+    it { is_expected.to contain_file(title).with_content /^THIS IS A post SCRIPT!$/ }
+  end
+
 end

--- a/spec/fixtures/templates/post_opts.erb
+++ b/spec/fixtures/templates/post_opts.erb
@@ -1,0 +1,1 @@
+THIS IS A <%= @fragment_variables['kind'] %> SCRIPT WITH <%= @fragment_variables['opts'] %>!

--- a/spec/fixtures/templates/pre.erb
+++ b/spec/fixtures/templates/pre.erb
@@ -1,0 +1,1 @@
+THIS IS A <%= @fragment_variables['other_kind'] %> SCRIPT!

--- a/templates/kickstart.erb
+++ b/templates/kickstart.erb
@@ -48,7 +48,7 @@ repo --name <%= name %> <%= repo.map { |k,v| "--#{k} #{v}" }.join(' ') %>
      end
 -%>
 # Packages Section
-%packages<% if !package_options.to_s.empty? -%><%= " #{package_options}" %><% end %>
+%packages<% unless package_options.to_s.empty? -%><%= " #{package_options}" %><% end %>
   <%- package_list.each do |package| -%>
 <%= package %>
   <%- end -%>

--- a/templates/kickstart.erb
+++ b/templates/kickstart.erb
@@ -37,10 +37,19 @@ repo --name <%= name %> <%= repo.map { |k,v| "--#{k} #{v}" }.join(' ') %>
   <%- end -%>
 <% end -%>
 
-<% if @packages && ! @packages.empty? -%>
+<%
+   package_options, package_list = nil
+   if @packages && ! @packages.empty?
+     if @packages.is_a?(Array)
+       package_list = @packages
+     elsif @packages.is_a?(Hash)
+       package_options = (@packages.has_key?('options') ? @packages['options'] : '')
+       package_list = (@packages.has_key?('package_list') ? @packages['package_list'] : [])
+     end
+-%>
 # Packages Section
-%packages
-  <%- @packages.each do |package| -%>
+%packages<% if !package_options.to_s.empty? -%><%= " #{package_options}" %><% end %>
+  <%- package_list.each do |package| -%>
 <%= package %>
   <%- end -%>
 %end

--- a/templates/kickstart.erb
+++ b/templates/kickstart.erb
@@ -63,8 +63,8 @@ repo --name <%= name %> <%= repo.map { |k,v| "--#{k} #{v}" }.join(' ') %>
 <%= scope.function_template([template]) %>
 ########## END: <%= template %>
     <%- end -%>
-  <%- end -%>
 %end
+  <%- end -%>
 <% end -%>
 
 <% if @addons && ! @addons.empty? -%>


### PR DESCRIPTION
There are [package options](https://access.redhat.com/documentation/en-US/Red_Hat_Enterprise_Linux/7/html/Installation_Guide/sect-kickstart-syntax.html#sect-kickstart-packages) available for kickstarting RHEL/CentOS.

Support added for these, via a Hash for the 'packages' parameter.  For backwards compatibility, the Array version of the package still works, and the code will check/validate Arrays or Hashes.