### PR TITLE
Support pre and post block with inline commands

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -72,6 +72,12 @@
 # [*partition_configuration*]
 #   Hash. A separate section to define your partition configuration. This
 #   follows the same rules as the 'commands' parameter.
+# [*pre*]
+#   Array. An array of commands to be injected in the 'pre' section of the Kickstart file.
+#
+# [*post*]
+#   Array. An array of commands to be injected in the 'post' section of the Kickstart file.
+#
 # [*fragments*]
 #   Hash. An hash of fragments to be evaluated in the template. These are
 #   passed as an argument to the `template` function. The hash must have the
@@ -116,6 +122,8 @@ define kickstart (
   $repos                        = false,
   $packages                     = false,
   $partition_configuration      = false,
+  $post                         = false,
+  $pre                          = false,
   $fragments                    = false,
   $fragment_variables           = false,
   $addons                       = false,
@@ -138,6 +146,8 @@ define kickstart (
     }
   }
   if $partition_configuration { validate_hash($partition_configuration) }
+  if $pre { validate_array($pre) }
+  if $post { validate_array($post) }
   if $fragments { validate_hash($fragments) }
   if $fragment_variables { validate_hash($fragment_variables) }
   if $addons { validate_hash($addons) }

--- a/templates/kickstart.erb
+++ b/templates/kickstart.erb
@@ -55,6 +55,15 @@ repo --name <%= name %> <%= repo.map { |k,v| "--#{k} #{v}" }.join(' ') %>
 %end
 <% end -%>
 
+#Pre section from inline array
+<% if @pre && ! @pre.empty? -%>
+%pre
+  <%- @pre.each do |pre_cmd| -%>
+<%= pre_cmd %>
+  <%- end -%>
+%end
+<% end -%>
+
 <% if @fragments && ! @fragments.empty? -%>
   <%- @fragments.each do |section, templates| -%>
 %<%= section %>
@@ -65,6 +74,15 @@ repo --name <%= name %> <%= repo.map { |k,v| "--#{k} #{v}" }.join(' ') %>
     <%- end -%>
 %end
   <%- end -%>
+<% end -%>
+
+#Post section from inline array
+<% if @post && ! @post.empty? -%>
+%post
+  <%- @post.each do |post_cmd| -%>
+<%= post_cmd %>
+  <%- end -%>
+%end
 <% end -%>
 
 <% if @addons && ! @addons.empty? -%>
@@ -81,4 +99,3 @@ repo --name <%= name %> <%= repo.map { |k,v| "--#{k} #{v}" }.join(' ') %>
   <%- end -%>
 %end
 <% end -%>
-

--- a/templates/kickstart.erb
+++ b/templates/kickstart.erb
@@ -55,8 +55,8 @@ repo --name <%= name %> <%= repo.map { |k,v| "--#{k} #{v}" }.join(' ') %>
 %end
 <% end -%>
 
-#Pre section from inline array
 <% if @pre && ! @pre.empty? -%>
+#Pre section from inline array
 %pre
   <%- @pre.each do |pre_cmd| -%>
 <%= pre_cmd %>
@@ -76,8 +76,8 @@ repo --name <%= name %> <%= repo.map { |k,v| "--#{k} #{v}" }.join(' ') %>
   <%- end -%>
 <% end -%>
 
-#Post section from inline array
 <% if @post && ! @post.empty? -%>
+#Post section from inline array
 %post
   <%- @post.each do |post_cmd| -%>
 <%= post_cmd %>


### PR DESCRIPTION
Until now the module has only supported commands for pre and post blocks coming from ERB templates.
With this PR, two new arrays called 'pre' and 'post' take commands to be interpreted by the installer without the need to define them in a separate ERB template.